### PR TITLE
Remove title from ZT_Mermaid diagram

### DIFF
--- a/ZT_Mermaid
+++ b/ZT_Mermaid
@@ -1,5 +1,3 @@
-## Zero Trust Architecture Diagram – Golden State Water Treatment Facility
-
 ```mermaid
 flowchart TB
 


### PR DESCRIPTION
Removed title from the Zero Trust Architecture Diagram. ## Zero Trust Architecture Diagram – Golden State Water Treatment Facility